### PR TITLE
MySQL datetime handling

### DIFF
--- a/src/pod/babashka/sql.clj
+++ b/src/pod/babashka/sql.clj
@@ -58,6 +58,14 @@
     :array
     (into-array v)))
 
+(defmacro if-mysql [then else]
+  (if features/mysql?
+    then
+    else))
+
+(defmacro when-mysql [& body]
+  `(if-mysql (do ~@body) nil))
+
 (defmacro if-pg [then else]
   (if features/postgresql?
     then
@@ -96,6 +104,22 @@
                          (vec arr))]
            coerced)
     :else #_=> x))
+
+(when-mysql
+    (defn serialize [opts x]
+      (cond
+        #_? (instance? java.time.LocalDateTime x)
+        #_=> {::val (str x)
+              ::read :local-date-time}
+        #_? (instance? java.sql.Array x)
+        #_=> (let [arr (.getArray ^java.sql.Array x)
+                   coerce-opt (get-in opts [:pod.babashka.sql/read :array])
+                   coerced (case coerce-opt
+                             :array {::val (vec arr)
+                                     ::read :array}
+                             (vec arr))]
+               coerced)
+        :else #_=> x)))
 
 (when-pg
     (defn serialize [opts x]
@@ -276,7 +300,8 @@
                (if-let [t (::read x)]
                  (let [v (::val x)]
                    (case t
-                     :array (into-array v)))
+                     :array (into-array v)
+                     :local-date-time (java.time.LocalDateTime/parse v)))
                  x)
                x))))
 

--- a/test/pod/babashka/mysql_test.clj
+++ b/test/pod/babashka/mysql_test.clj
@@ -80,4 +80,24 @@
                   (db/execute! x ["insert into foo values (8);"]))))
           (is (= [#:foo{:foo 1} #:foo{:foo 2} #:foo{:foo 3} #:foo{:foo 4}
                   #:foo{:foo 5} #:foo{:foo 6} #:foo{:foo 7}]
-                (db/execute! db  ["select * from foo;"]))))))))
+                (db/execute! db  ["select * from foo;"])))))
+      (testing "java.time classes"
+        (is (instance? java.time.LocalDateTime
+              (-> (db/execute! db ["select now();"]) ffirst val)))
+        (db/with-transaction [x (db/get-connection db)]
+          (db/execute! x ["set time_zone = '+00:00';"]) ;; UTC isn't always recognized, so we specify the offset
+          (db/execute! x ["create table java_time (d date, dt datetime, ts timestamp);"])
+          (db/execute! x ["insert into java_time values (?, ?, ?), (?, ?, ?), (?, ?, ?);"
+                          "2021-05-08" nil nil ;; Her last day
+                          nil "2021-05-08 18:35:00" nil ;; Her last message
+                          nil nil "2021-06-23 00:00:00"]) ;; She would have been 23
+          (is (= [{:java_time/d #inst "2021-05-08T05:00:00"}]
+                (db/execute! x ["select d from java_time where d is not null;"])))
+          (is (= [{:java_time/dt (java.time.LocalDateTime/parse "2021-05-08T18:35")}]
+                (db/execute! x ["select dt from java_time where dt is not null;"])))
+          (let [now (-> (db/execute! db ["select unix_timestamp(now());"]) ffirst val)]
+            (is (= #{now 1624406400}
+                  (->> ["select unix_timestamp(ts) from java_time;"]
+                    (db/execute! x)
+                    (mapcat vals)
+                    set)))))))))


### PR DESCRIPTION
Currently we get an exception when the MySQL driver returns a LocalDateTime. This handles LocalDateTimes correctly and adds tests against now() and the date, datetime, and timestamp types.

I decided not to implement any JSON conversions because the driver returns JSON as strings rather than JSON objects like the postgres driver does, so we can't convert them automatically. I recommend calling the JSON generation and parsing functions manually when using MySQL.

Closes #8.