### PR TITLE
add minimal support for mysql unix domain sockets.

### DIFF
--- a/java-src/mysql/pod/babashka/sql/UnixSocket.java
+++ b/java-src/mysql/pod/babashka/sql/UnixSocket.java
@@ -1,0 +1,64 @@
+package pod.babashka.mysql;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.channels.SocketChannel;
+import java.nio.ByteBuffer;
+
+public class UnixSocket extends Socket {
+
+    private SocketChannel channel = null;
+
+    public UnixSocket(SocketChannel channel) {
+	this.channel = channel;
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+	return this.channel;
+    }
+
+    @Override
+    public boolean isConnected() {
+	return this.channel.isConnected();
+    }
+
+    @Override
+    public void close() throws IOException {
+	this.channel.close();
+    }
+
+    public InputStream getInputStream(){
+	final SocketChannel channel = this.channel;
+	return new InputStream () {
+	    @Override
+	    public int read() throws IOException {
+		//System.out.print("read() ");
+		ByteBuffer buf = ByteBuffer.allocate(1);
+		int res = channel.read(buf);
+		if (res < 0){
+		    return res;
+		}
+		return buf.get(0) & 0xFF;
+	    }
+	};
+    }
+
+    public OutputStream getOutputStream(){
+	final SocketChannel channel = this.channel;
+	return new OutputStream() {
+	    @Override
+	    public void write(int b) throws IOException {
+		byte[] ba = new byte[]{(byte)b};
+		ByteBuffer buf = ByteBuffer.wrap(ba);
+		channel.write(buf);
+	    }
+	    @Override
+	    public void write(byte[] b) throws IOException {
+		long r = channel.write(ByteBuffer.wrap(b));
+	    };
+	};
+    }
+}

--- a/java-src/mysql/pod/babashka/sql/UnixSocketFactory.java
+++ b/java-src/mysql/pod/babashka/sql/UnixSocketFactory.java
@@ -1,0 +1,59 @@
+package pod.babashka.mysql;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.UnixDomainSocketAddress;
+import java.net.SocketAddress;
+import java.net.Socket;
+import java.nio.file.Path;
+import java.nio.channels.SocketChannel;
+
+import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.conf.RuntimeProperty;
+import com.mysql.cj.protocol.ExportControlled;
+import com.mysql.cj.protocol.ServerSession;
+import com.mysql.cj.protocol.SocketConnection;
+import com.mysql.cj.protocol.SocketFactory;
+import com.mysql.cj.ServerVersion;
+
+public class UnixSocketFactory implements SocketFactory {
+    private Socket rawSocket;
+    private Socket sslSocket;
+
+    public UnixSocketFactory() {
+    }
+
+    @SuppressWarnings({"unchecked", "exports"})
+    @Override
+    public <T extends Closeable> T connect(String hostname, int portNumber, PropertySet props,
+					   int loginTimeout) throws IOException {
+	RuntimeProperty<String> prop = props.getStringProperty("pod.babashka.mysql.file");
+	String sock;
+	if (prop != null && !prop.isExplicitlySet()) {
+	    sock = prop.getStringValue();
+	} else {
+	    sock = "/tmp/mysql.sock";
+	}
+	final Path socketPath = new File(sock).toPath();
+	System.out.println("connecting to socket:" + socketPath);
+	
+	SocketAddress address = UnixDomainSocketAddress.of(socketPath);
+	this.rawSocket = new UnixSocket(SocketChannel.open(address));
+	System.out.println("class: " + this.rawSocket);
+	//System.out.println("is: " + this.rawSocket.getInputStream());
+	this.sslSocket = rawSocket;
+	return (T) rawSocket;
+    }
+
+    @SuppressWarnings({"unchecked", "exports"})
+    @Override
+    public <T extends Closeable> T performTlsHandshake(SocketConnection socketConnection,
+						       ServerSession serverSession) throws IOException {
+	ServerVersion version = serverSession == null ? null : serverSession.getServerVersion();
+		this.sslSocket = ExportControlled.performTlsHandshake(this.rawSocket,
+								      socketConnection,
+								      version);
+	return (T) this.sslSocket;
+    }
+}

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,8 @@
              :feature/postgresql {:dependencies [[org.postgresql/postgresql "42.2.20"]]}
              :feature/mssql {:dependencies [[com.microsoft.sqlserver/mssql-jdbc "9.2.0.jre11"]]}
              :feature/hsqldb {:dependencies [[org.hsqldb/hsqldb "2.6.0"]]}
-             :feature/mysql {:dependencies [[mysql/mysql-connector-java "8.0.25"]]}
+             :feature/mysql {:dependencies [[mysql/mysql-connector-java "8.0.25"]]
+                             :java-source-paths ["java-src/mysql/"]}
              :feature/oracle {:dependencies [[io.helidon.integrations.db/ojdbc "2.3.0"]]}} ; ojdbc10 + GraalVM config, by Oracle
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_user


### PR DESCRIPTION
This is a minimal request for comments implementation for #53 

i've tested so far using the following code (using a vanilla mysql install):

```clojure
(ns pod.babashka.test
  (:require [next.jdbc :as jdbc])
  (:gen-class))

(def uri "jdbc:mysql:///mysql?user=root&socketFactory=pod.babashka.mysql.UnixSocketFactory")
(defn get-connection [db-spec]
  (jdbc/get-connection {:jdbcUrl db-spec
                        "pod.babashka.mysql.file" "/tmp/mysql.sock"}))

(defn -main []
  (try
    (with-open [c (get-connection uri)]
      (println (jdbc/execute! c ["select version();"])))
    (catch Throwable t
      (.printStackTrace t))))

```

```bash
> POD_DB_TYPE=mysql lein do compile, clean, with-profiles +feature/mysql run -m pod.babashka.test
Compiling 2 source files to /Users/mknoszlig/work/babashka-sql-pods/target/classes
connecting to socket:/tmp/mysql.sock
class: Socket[addr=null,port=0,localport=0]
[{:version() 8.0.28}]
```

Is there anything I need to consider for the native build (aside from using the correct graalvm version)? Will the java classes get picked up correctly?