### PR TITLE
Newer Graal and partial interval type

### DIFF
--- a/reflection-postgresql.json
+++ b/reflection-postgresql.json
@@ -1,2 +1,14 @@
 [{"name": "org.postgresql.jdbc.PgConnection",
-  "methods" : [{"name":"close"}]}]
+  "methods" : [{"name":"close"}]},
+ {"name": "org.postgresql.util.PGInterval",
+  "allDeclaredConstructors": true,
+  "allPublicConstructors": true,
+  "allDeclaredMethods": true,
+  "allPublicMethods": true,
+  "allDeclaredFields": true,
+  "allPublicFields": true,
+  "unsafeAllocated": true,
+  "queryAllDeclaredConstructors" : true,
+  "queryAllPublicConstructors" : true,
+  "queryAllDeclaredMethods" : true,
+  "queryAllPublicMethods" : true}]

--- a/script/compile
+++ b/script/compile
@@ -91,6 +91,7 @@ args=( "-jar" "$JAR"
        "--initialize-at-run-time=com.microsoft.sqlserver.jdbc.SQLServerFMTQuery"
        "--initialize-at-run-time=com.microsoft.sqlserver.jdbc.SQLServerBouncyCastleLoader"
        "--initialize-at-run-time=com.microsoft.sqlserver.jdbc.SQLServerMSAL4JUtils"
+       "-EPOD_DB_TYPE"
        "$BABASHKA_XMX" )
 
 if [ "$POD_DB_TYPE" = "mssql" ]

--- a/src/pod/babashka/sql.clj
+++ b/src/pod/babashka/sql.clj
@@ -289,7 +289,11 @@
                                                 :string
                                                 (.getValue x)
                                                 ;; default JSON handler
-                                                (json/parse-string (.getValue x) true)))]
+                                                (json/parse-string (.getValue x) true))
+                                              "interval"
+                                              ;; there is no strictly correct way to convert from PGInterval to Java time objects,
+                                              ;; so punt on it and just convert it to a string
+                                              (.getValue x))]
                                 coerced)))))
 
 (def base-write-map

--- a/test/pod/babashka/postgresql_test.clj
+++ b/test/pod/babashka/postgresql_test.clj
@@ -122,4 +122,5 @@
     (testing "interval"
       (is (db/execute! db ["create table interval_table (interval_col interval);"]))
       (is (db/execute! db ["insert into interval_table(interval_col) values ('00:00:00'::interval);"]))
-      (is (= [#:interval_table{:interval_col Duration/ZERO}] (db/execute! db ["SELECT interval_col from interval_table;"]))))))
+      (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 0 hours 0 mins 0.0 secs"}]
+             (db/execute! db ["SELECT interval_col from interval_table;"]))))))

--- a/test/pod/babashka/postgresql_test.clj
+++ b/test/pod/babashka/postgresql_test.clj
@@ -4,7 +4,8 @@
   (:require [babashka.pods :as pods]
             [clojure.test :refer [deftest is testing]])
   (:import [io.zonky.test.db.postgres.embedded EmbeddedPostgres]
-           [java.util Date Arrays]))
+           [java.util Date Arrays]
+           [java.time Duration]))
 
 (pods/load-pod (if (= "native" (System/getenv "POD_TEST_ENV"))
                  "./pod-babashka-postgresql"
@@ -117,4 +118,8 @@
                           {:pod.babashka.sql/read {:jsonb :parse}})))
       (is (= [#:jsonb_table{:jsonb_col "{\"a\": 1}"}]
              (db/execute! db ["select * from jsonb_table values;"]
-                          {:pod.babashka.sql/read {:jsonb :string}}))))))
+                          {:pod.babashka.sql/read {:jsonb :string}}))))
+    (testing "interval"
+      (is (db/execute! db ["create table interval_table (interval_col interval);"]))
+      (is (db/execute! db ["insert into interval_table(interval_col) values ('00:00:00'::interval);"]))
+      (is (= [#:interval_table{:interval_col Duration/ZERO}] (db/execute! db ["SELECT interval_col from interval_table;"]))))))

--- a/test/pod/babashka/postgresql_test.clj
+++ b/test/pod/babashka/postgresql_test.clj
@@ -121,9 +121,12 @@
                           {:pod.babashka.sql/read {:jsonb :string}}))))
     (testing "interval"
       (is (db/execute! db ["create table interval_table (interval_col interval);"]))
-      (is (db/execute! db ["insert into interval_table(interval_col) values ('02:02:02')"]))
+      (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 2 hours 2 mins 2.0 secs"}]
+             (db/execute! db ["insert into interval_table(interval_col) values ('02:02:02') returning *"])))
       (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 2 hours 2 mins 2.0 secs"}]
              (db/execute! db ["SELECT interval_col from interval_table;"])))
+      (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 3 hours 3 mins 3.0 secs"}]
+             (db/execute! db ["insert into interval_table(interval_col) values (?)" "03:03:03"])))
       (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 0 hours 0 mins 0.0 secs"}
               #:interval_table{:interval_col "0 years 0 mons 0 days 1 hours 1 mins 1.0 secs"}]
              (sql/insert-multi! db :interval_table [:interval_col] [["00:00:00"] ["01:01:01"]]))))))

--- a/test/pod/babashka/postgresql_test.clj
+++ b/test/pod/babashka/postgresql_test.clj
@@ -121,8 +121,9 @@
                           {:pod.babashka.sql/read {:jsonb :string}}))))
     (testing "interval"
       (is (db/execute! db ["create table interval_table (interval_col interval);"]))
-      (is (= [#:interval_table{:interval_col ""} #:interval_table{:interval_col ""}]
-             (sql/insert-multi! db :interval_table [:interval_col] [[(into-array ["00:00:00"])]
-                                                                   [(into-array ["01:01:01"])]])))
-      (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 0 hours 0 mins 0.0 secs"}]
-             (db/execute! db ["SELECT interval_col from interval_table;"]))))))
+      (is (db/execute! db ["insert into interval_table(interval_col) values ('02:02:02')"]))
+      (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 2 hours 2 mins 2.0 secs"}]
+             (db/execute! db ["SELECT interval_col from interval_table;"])))
+      (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 0 hours 0 mins 0.0 secs"}
+              #:interval_table{:interval_col "0 years 0 mons 0 days 1 hours 1 mins 1.0 secs"}]
+             (sql/insert-multi! db :interval_table [:interval_col] [["00:00:00"] ["01:01:01"]]))))))

--- a/test/pod/babashka/postgresql_test.clj
+++ b/test/pod/babashka/postgresql_test.clj
@@ -121,6 +121,8 @@
                           {:pod.babashka.sql/read {:jsonb :string}}))))
     (testing "interval"
       (is (db/execute! db ["create table interval_table (interval_col interval);"]))
-      (is (db/execute! db ["insert into interval_table(interval_col) values ('00:00:00'::interval);"]))
+      (is (= [#:interval_table{:interval_col ""} #:interval_table{:interval_col ""}]
+             (sql/insert-multi! db :interval_table [:interval_col] [[(into-array ["00:00:00"])]
+                                                                   [(into-array ["01:01:01"])]])))
       (is (= [#:interval_table{:interval_col "0 years 0 mons 0 days 0 hours 0 mins 0.0 secs"}]
              (db/execute! db ["SELECT interval_col from interval_table;"]))))))


### PR DESCRIPTION
I need to punt on this for now but just in case anyone else can pick it up. Apologies in advance for the big hammer I used fixing things in the reflections JSON, PGConnection was hiding what the real error is and this made it work. I'm confident someone more knowledgable about how to trace these things could figure out what it's trying to call.

This builds using GraalVM CE 23.0.2+7.1 on macos. The tests fail with these errors:

```
ERROR in (postgresql-test) (impl.clj:210)
interval
expected: (= [#:interval_table{:interval_col "0 years 0 mons 0 days 3 hours 3 mins 3.0 secs"}] (db/execute! db ["insert into interval_table(interval_col) values (?)" "03:03:03"]))
  actual: clojure.lang.ExceptionInfo: ERROR: column "interval_col" is of type interval but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.
  Position: 50
{:type "class org.postgresql.util.PSQLException"}
 at babashka.pods.impl$processor.invokeStatic (impl.clj:210)
    babashka.pods.impl$processor.invoke (impl.clj:139)
    babashka.pods.jvm$load_pod$fn__3123.invoke (jvm.clj:62)
    clojure.core$binding_conveyor_fn$fn__5842.invoke (core.clj:2047)
    clojure.lang.AFn.call (AFn.java:18)
    java.util.concurrent.FutureTask.run (FutureTask.java:317)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1144)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:642)
    java.lang.Thread.run (Thread.java:1575)

ERROR in (postgresql-test) (impl.clj:210)
interval
expected: (= [#:interval_table{:interval_col "0 years 0 mons 0 days 0 hours 0 mins 0.0 secs"} #:interval_table{:interval_col "0 years 0 mons 0 days 1 hours 1 mins 1.0 secs"}] (sql/insert-multi! db :interval_table [:interval_col] [["00:00:00"] ["01:01:01"]]))
  actual: clojure.lang.ExceptionInfo: ERROR: column "interval_col" is of type interval but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.
  Position: 51
{:type "class org.postgresql.util.PSQLException"}
 at babashka.pods.impl$processor.invokeStatic (impl.clj:210)
    babashka.pods.impl$processor.invoke (impl.clj:139)
    babashka.pods.jvm$load_pod$fn__3123.invoke (jvm.clj:62)
    clojure.core$binding_conveyor_fn$fn__5842.invoke (core.clj:2047)
    clojure.lang.AFn.call (AFn.java:18)
    java.util.concurrent.FutureTask.run (FutureTask.java:317)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1144)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:642)
    java.lang.Thread.run (Thread.java:1575)

Ran 1 tests containing 49 assertions.
0 failures, 2 errors.
```

The code can read the interval type, it just can't cast a string value to it.

